### PR TITLE
Add FastAPI website with arrests, incidents, 311, and stops views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,25 @@ The repo is being actively developed toward three goals:
 
 A primarily Python backend is preferred. BigQuery is attractive for making datasets publicly accessible independent of the website. No final decision has been made — evaluate tradeoffs when beginning the site build.
 
+## Web Application
+
+The site is built with **FastAPI + DuckDB + Plotly + Leaflet**. DuckDB queries the gzip CSVs in `data/clean/` directly — no separate database setup needed. Charts are rendered client-side via the Plotly JS CDN.
+
+```
+app/
+├── main.py          # FastAPI app, mounts routers and static files
+├── data.py          # All DuckDB queries (import this for new data access)
+├── routers/         # One file per data topic (arrests.py, incidents.py, ...)
+├── templates/       # Jinja2 HTML templates
+│   ├── base.html    # Nav, CDN imports, footer
+│   ├── index.html   # Front page
+│   ├── arrests/
+│   └── incidents/
+└── static/css/style.css
+```
+
+To add a new data topic: add queries to `data.py`, create `routers/<topic>.py`, add templates under `templates/<topic>/`, and register the router in `main.py`.
+
 ## Environment
 
 The project uses [uv](https://docs.astral.sh/uv/) for package and environment management on Python 3.14. `pyproject.toml` is the source of truth for dependencies — do not edit `requirements.txt` (kept only as a historical reference). Add new dependencies with `uv add <package>`.
@@ -56,6 +75,9 @@ uv run pytest tests/unit/test_data_completeness.py::test_years_completeness
 
 # Lint
 uv run ruff check scripts/ tests/
+
+# Run the dev web server (auto-reloads on file changes)
+uv run uvicorn app.main:app --reload --port 8000
 
 # Add a new dependency
 uv add <package>

--- a/app/data.py
+++ b/app/data.py
@@ -10,6 +10,12 @@ THREE11 = "read_csv_auto('data/clean/311_data_part_*.csv.gz')"
 # 311 ward values are mixed strings ('1', '1.0') — normalize to integer
 _311_WARD = "TRY_CAST(TRY_CAST(ward AS DOUBLE) AS INTEGER)"
 
+# Stop district values are mixed: '7D' (newer data) and '7' (older) — normalize to 'NND' format
+_STOP_DISTRICT = "CASE WHEN stop_district LIKE '%D' THEN stop_district ELSE stop_district || 'D' END"
+
+DISTRICTS = ['1D', '2D', '3D', '4D', '5D', '6D', '7D']
+STOPS_CURRENT_YEAR = 2024  # most recent complete year in stops data
+
 WARDS = [str(w) for w in range(1, 9)]
 CURRENT_YEAR = 2024
 PREV_YEAR = 2023
@@ -239,6 +245,112 @@ def requests_status_summary(year=CURRENT_YEAR, ward: str | None = None) -> list[
     return [{"status": r[0], "requests": r[1]} for r in rows]
 
 
+# ── Police Stops ──────────────────────────────────────────────────────────────
+
+def _stop_district_filter(district: str | None) -> str:
+    return f"AND {_STOP_DISTRICT} = '{district}'" if district else ""
+
+
+def stops_by_year(district: str | None = None) -> list[dict]:
+    geo = _stop_district_filter(district)
+    rows = _con().execute(f"""
+        SELECT year, COUNT(*) AS stops
+        FROM {STOPS}
+        WHERE year IS NOT NULL {geo}
+        GROUP BY year ORDER BY year
+    """).fetchall()
+    return [{"year": r[0], "stops": r[1]} for r in rows]
+
+
+def stops_by_district(year=STOPS_CURRENT_YEAR) -> list[dict]:
+    rows = _con().execute(f"""
+        SELECT {_STOP_DISTRICT} AS district, COUNT(*) AS stops
+        FROM {STOPS}
+        WHERE year = {year}
+        GROUP BY district ORDER BY district
+    """).fetchall()
+    return [{"district": r[0], "stops": r[1]} for r in rows]
+
+
+def stops_by_type(year=STOPS_CURRENT_YEAR, district: str | None = None) -> list[dict]:
+    geo = _stop_district_filter(district)
+    rows = _con().execute(f"""
+        SELECT stop_type, COUNT(*) AS stops
+        FROM {STOPS}
+        WHERE year = {year} AND stop_type IS NOT NULL {geo}
+        GROUP BY stop_type ORDER BY stops DESC
+    """).fetchall()
+    return [{"stop_type": r[0], "stops": r[1]} for r in rows]
+
+
+def stops_by_ethnicity(year=STOPS_CURRENT_YEAR, district: str | None = None) -> list[dict]:
+    geo = _stop_district_filter(district)
+    rows = _con().execute(f"""
+        SELECT ethnicity, COUNT(*) AS stops
+        FROM {STOPS}
+        WHERE year = {year} AND ethnicity IS NOT NULL {geo}
+        GROUP BY ethnicity ORDER BY stops DESC
+    """).fetchall()
+    return [{"ethnicity": r[0], "stops": r[1]} for r in rows]
+
+
+def stops_by_gender(year=STOPS_CURRENT_YEAR, district: str | None = None) -> list[dict]:
+    geo = _stop_district_filter(district)
+    rows = _con().execute(f"""
+        SELECT gender, COUNT(*) AS stops
+        FROM {STOPS}
+        WHERE year = {year} AND gender IS NOT NULL {geo}
+        GROUP BY gender ORDER BY stops DESC
+    """).fetchall()
+    return [{"gender": r[0], "stops": r[1]} for r in rows]
+
+
+def stops_search_summary(year=STOPS_CURRENT_YEAR, district: str | None = None) -> dict:
+    """Return counts of stops, searches, and arrests for the given filters."""
+    geo = _stop_district_filter(district)
+    row = _con().execute(f"""
+        SELECT
+            COUNT(*) AS total,
+            SUM(CASE WHEN person_search_prob_cause = 1
+                       OR person_search_consent = 1
+                       OR person_search_warrant = 1 THEN 1 ELSE 0 END) AS searched,
+            SUM(CASE WHEN traffic_arrest = 1 THEN 1 ELSE 0 END) AS arrested
+        FROM {STOPS}
+        WHERE year = {year} {geo}
+    """).fetchone()
+    total, searched, arrested = row
+    return {
+        "total": total,
+        "searched": searched,
+        "arrested": arrested,
+        "search_rate": round(100 * searched / total, 1) if total else 0,
+        "arrest_rate": round(100 * arrested / total, 1) if total else 0,
+    }
+
+
+def stops_search_by_ethnicity(year=STOPS_CURRENT_YEAR, district: str | None = None) -> list[dict]:
+    """Search rate broken down by ethnicity."""
+    geo = _stop_district_filter(district)
+    rows = _con().execute(f"""
+        SELECT
+            ethnicity,
+            COUNT(*) AS stops,
+            SUM(CASE WHEN person_search_prob_cause = 1
+                       OR person_search_consent = 1
+                       OR person_search_warrant = 1 THEN 1 ELSE 0 END) AS searched,
+            ROUND(100.0 * SUM(CASE WHEN person_search_prob_cause = 1
+                                     OR person_search_consent = 1
+                                     OR person_search_warrant = 1 THEN 1 ELSE 0 END)
+                  / NULLIF(COUNT(*), 0), 1) AS search_rate
+        FROM {STOPS}
+        WHERE year = {year} AND ethnicity IS NOT NULL {geo}
+        GROUP BY ethnicity
+        HAVING COUNT(*) >= 50
+        ORDER BY stops DESC
+    """).fetchall()
+    return [{"ethnicity": r[0], "stops": r[1], "searched": r[2], "search_rate": r[3]} for r in rows]
+
+
 # ── Summary stats for front page ──────────────────────────────────────────────
 
 def citywide_summary() -> dict:
@@ -249,6 +361,8 @@ def citywide_summary() -> dict:
     incidents_prev = con.execute(f"SELECT COUNT(*) FROM {INCIDENTS} WHERE year = {PREV_YEAR}").fetchone()[0]
     req_curr = con.execute(f"SELECT COUNT(*) FROM {THREE11} WHERE YEAR(ADDDATE) = {CURRENT_YEAR}").fetchone()[0]
     req_prev = con.execute(f"SELECT COUNT(*) FROM {THREE11} WHERE YEAR(ADDDATE) = {PREV_YEAR}").fetchone()[0]
+    stops_curr = con.execute(f"SELECT COUNT(*) FROM {STOPS} WHERE year = {STOPS_CURRENT_YEAR}").fetchone()[0]
+    stops_prev = con.execute(f"SELECT COUNT(*) FROM {STOPS} WHERE year = {PREV_YEAR}").fetchone()[0]
 
     def pct(curr, prev):
         return round(100 * (curr - prev) / prev, 1) if prev else 0
@@ -263,6 +377,10 @@ def citywide_summary() -> dict:
         "req_curr": req_curr,
         "req_prev": req_prev,
         "req_pct": pct(req_curr, req_prev),
+        "stops_curr": stops_curr,
+        "stops_prev": stops_prev,
+        "stops_pct": pct(stops_curr, stops_prev),
+        "stops_year": STOPS_CURRENT_YEAR,
         "current_year": CURRENT_YEAR,
         "prev_year": PREV_YEAR,
     }

--- a/app/data.py
+++ b/app/data.py
@@ -7,10 +7,11 @@ INCIDENTS = "read_csv_auto('data/clean/incident_data_all.csv.gz')"
 STOPS = "read_csv_auto('data/clean/stop_data.csv.gz')"
 THREE11 = "read_csv_auto('data/clean/311_data_part_*.csv.gz')"
 
-# 311 ward values are mixed strings ('1', '1.0') — normalize to integer
-_311_WARD = "TRY_CAST(TRY_CAST(ward AS DOUBLE) AS INTEGER)"
-
-# Stop district values are mixed: '7D' (newer data) and '7' (older) — normalize to 'NND' format
+# Normalization expressions handle both dirty existing files and clean post-ETL files.
+# After ETL re-run these will be no-ops.
+_311_WARD = "TRY_CAST(TRY_CAST(ward AS DOUBLE) AS INTEGER)::VARCHAR"
+_INCIDENT_WARD = "TRY_CAST(ward AS INTEGER)::VARCHAR"
+_INCIDENT_DISTRICT = "CASE WHEN district IS NULL THEN NULL WHEN CAST(district AS VARCHAR) LIKE '%D' THEN CAST(district AS VARCHAR) ELSE CAST(TRY_CAST(district AS INTEGER) AS VARCHAR) || 'D' END"
 _STOP_DISTRICT = "CASE WHEN stop_district LIKE '%D' THEN stop_district ELSE stop_district || 'D' END"
 
 DISTRICTS = ['1D', '2D', '3D', '4D', '5D', '6D', '7D']
@@ -122,7 +123,7 @@ def available_smds(anc_id: str) -> list[str]:
 # ── Incidents ─────────────────────────────────────────────────────────────────
 
 def incidents_by_year(ward: str | None = None) -> list[dict]:
-    geo = f"AND CAST(ward AS INTEGER) = {ward}" if ward else ""
+    geo = f"AND {_INCIDENT_WARD} = '{ward}'" if ward else ""
     rows = _con().execute(f"""
         SELECT year, COUNT(*) AS incidents
         FROM {INCIDENTS}
@@ -133,7 +134,7 @@ def incidents_by_year(ward: str | None = None) -> list[dict]:
 
 
 def incidents_by_offense(year=CURRENT_YEAR, ward: str | None = None) -> list[dict]:
-    geo = f"AND CAST(ward AS INTEGER) = {ward}" if ward else ""
+    geo = f"AND {_INCIDENT_WARD} = '{ward}'" if ward else ""
     rows = _con().execute(f"""
         SELECT offense, COUNT(*) AS incidents
         FROM {INCIDENTS}
@@ -147,7 +148,7 @@ def incidents_by_offense(year=CURRENT_YEAR, ward: str | None = None) -> list[dic
 # ── 311 Service Requests ──────────────────────────────────────────────────────
 
 def _311_ward_filter(ward: str | None) -> str:
-    return f"AND {_311_WARD} = {ward}" if ward else ""
+    return f"AND {_311_WARD} = '{ward}'" if ward else ""
 
 
 def requests_by_year(ward: str | None = None) -> list[dict]:
@@ -189,10 +190,10 @@ def requests_by_agency(year=CURRENT_YEAR, ward: str | None = None) -> list[dict]
 
 def requests_by_ward(year=CURRENT_YEAR) -> list[dict]:
     rows = _con().execute(f"""
-        SELECT CAST({_311_WARD} AS VARCHAR) AS ward, COUNT(*) AS requests
+        SELECT TRY_CAST(TRY_CAST(ward AS DOUBLE) AS INTEGER)::VARCHAR AS ward, COUNT(*) AS requests
         FROM {THREE11}
         WHERE YEAR(ADDDATE) = {year}
-          AND {_311_WARD} BETWEEN 1 AND 8
+          AND TRY_CAST(TRY_CAST(ward AS DOUBLE) AS INTEGER) BETWEEN 1 AND 8
         GROUP BY ward ORDER BY ward
     """).fetchall()
     return [{"ward": r[0], "requests": r[1]} for r in rows]

--- a/app/data.py
+++ b/app/data.py
@@ -1,0 +1,158 @@
+"""DuckDB query helpers. All queries read directly from gzip CSVs — no separate DB needed."""
+
+import duckdb
+
+ARRESTS = "read_csv_auto('data/clean/arrest_data.csv.gz')"
+INCIDENTS = "read_csv_auto('data/clean/incident_data_all.csv.gz')"
+STOPS = "read_csv_auto('data/clean/stop_data.csv.gz')"
+
+WARDS = list(range(1, 9))
+CURRENT_YEAR = 2024
+PREV_YEAR = 2023
+
+
+def _con() -> duckdb.DuckDBPyConnection:
+    return duckdb.connect()
+
+
+def _geo_filter(geo_type: str | None, geo_id: str | None) -> str:
+    """Return a WHERE clause fragment for geographic filtering."""
+    if not geo_type or not geo_id:
+        return ""
+    if geo_type == "ward":
+        return f"AND ward = {int(geo_id)}"
+    if geo_type == "anc":
+        return f"AND anc_id = '{geo_id}'"
+    if geo_type == "smd":
+        return f"AND smd_id = '{geo_id}'"
+    return ""
+
+
+# ── Arrests ──────────────────────────────────────────────────────────────────
+
+def arrests_by_year(geo_type=None, geo_id=None) -> list[dict]:
+    geo = _geo_filter(geo_type, geo_id)
+    rows = _con().execute(f"""
+        SELECT year, COUNT(*) AS arrests
+        FROM {ARRESTS}
+        WHERE year BETWEEN 2015 AND {CURRENT_YEAR} {geo}
+        GROUP BY year ORDER BY year
+    """).fetchall()
+    return [{"year": r[0], "arrests": r[1]} for r in rows]
+
+
+def arrests_by_category(year=CURRENT_YEAR, geo_type=None, geo_id=None) -> list[dict]:
+    geo = _geo_filter(geo_type, geo_id)
+    rows = _con().execute(f"""
+        SELECT category, COUNT(*) AS arrests
+        FROM {ARRESTS}
+        WHERE year = {year} AND category IS NOT NULL {geo}
+        GROUP BY category ORDER BY arrests DESC
+        LIMIT 15
+    """).fetchall()
+    return [{"category": r[0], "arrests": r[1]} for r in rows]
+
+
+def arrests_yoy(geo_type=None, geo_id=None) -> list[dict]:
+    """Year-over-year comparison by category for current vs prior year."""
+    geo = _geo_filter(geo_type, geo_id)
+    rows = _con().execute(f"""
+        WITH base AS (
+            SELECT category,
+                COUNT(*) FILTER (WHERE year = {PREV_YEAR}) AS prev,
+                COUNT(*) FILTER (WHERE year = {CURRENT_YEAR}) AS curr
+            FROM {ARRESTS}
+            WHERE year IN ({PREV_YEAR}, {CURRENT_YEAR})
+              AND category IS NOT NULL {geo}
+            GROUP BY category
+        )
+        SELECT category, prev, curr,
+               curr - prev AS change,
+               ROUND(100.0 * (curr - prev) / NULLIF(prev, 0), 1) AS pct_change
+        FROM base
+        WHERE prev > 0 OR curr > 0
+        ORDER BY curr DESC
+        LIMIT 20
+    """).fetchall()
+    return [
+        {"category": r[0], "prev": r[1], "curr": r[2], "change": r[3], "pct_change": r[4]}
+        for r in rows
+    ]
+
+
+def arrests_by_ward(year=CURRENT_YEAR) -> list[dict]:
+    rows = _con().execute(f"""
+        SELECT ward, COUNT(*) AS arrests
+        FROM {ARRESTS}
+        WHERE year = {year} AND ward IS NOT NULL
+        GROUP BY ward ORDER BY ward
+    """).fetchall()
+    return [{"ward": r[0], "arrests": r[1]} for r in rows]
+
+
+def available_ancs(geo_type=None, geo_id=None) -> list[str]:
+    geo = _geo_filter(geo_type, geo_id)
+    rows = _con().execute(f"""
+        SELECT DISTINCT anc_id FROM {ARRESTS}
+        WHERE anc_id IS NOT NULL {geo}
+        ORDER BY anc_id
+    """).fetchall()
+    return [r[0] for r in rows]
+
+
+def available_smds(anc_id: str) -> list[str]:
+    rows = _con().execute(f"""
+        SELECT DISTINCT smd_id FROM {ARRESTS}
+        WHERE anc_id = '{anc_id}' AND smd_id IS NOT NULL
+        ORDER BY smd_id
+    """).fetchall()
+    return [r[0] for r in rows]
+
+
+# ── Incidents ─────────────────────────────────────────────────────────────────
+
+def incidents_by_year(ward: int | None = None) -> list[dict]:
+    geo = f"AND ward = {ward}" if ward else ""
+    rows = _con().execute(f"""
+        SELECT year, COUNT(*) AS incidents
+        FROM {INCIDENTS}
+        WHERE year BETWEEN 2016 AND {CURRENT_YEAR} {geo}
+        GROUP BY year ORDER BY year
+    """).fetchall()
+    return [{"year": r[0], "incidents": r[1]} for r in rows]
+
+
+def incidents_by_offense(year=CURRENT_YEAR, ward: int | None = None) -> list[dict]:
+    geo = f"AND ward = {ward}" if ward else ""
+    rows = _con().execute(f"""
+        SELECT offense, COUNT(*) AS incidents
+        FROM {INCIDENTS}
+        WHERE year = {year} {geo}
+        GROUP BY offense ORDER BY incidents DESC
+        LIMIT 10
+    """).fetchall()
+    return [{"offense": r[0], "incidents": r[1]} for r in rows]
+
+
+# ── Summary stats for front page ──────────────────────────────────────────────
+
+def citywide_summary() -> dict:
+    con = _con()
+    arrests_curr = con.execute(f"SELECT COUNT(*) FROM {ARRESTS} WHERE year = {CURRENT_YEAR}").fetchone()[0]
+    arrests_prev = con.execute(f"SELECT COUNT(*) FROM {ARRESTS} WHERE year = {PREV_YEAR}").fetchone()[0]
+    incidents_curr = con.execute(f"SELECT COUNT(*) FROM {INCIDENTS} WHERE year = {CURRENT_YEAR}").fetchone()[0]
+    incidents_prev = con.execute(f"SELECT COUNT(*) FROM {INCIDENTS} WHERE year = {PREV_YEAR}").fetchone()[0]
+
+    def pct(curr, prev):
+        return round(100 * (curr - prev) / prev, 1) if prev else 0
+
+    return {
+        "arrests_curr": arrests_curr,
+        "arrests_prev": arrests_prev,
+        "arrests_pct": pct(arrests_curr, arrests_prev),
+        "incidents_curr": incidents_curr,
+        "incidents_prev": incidents_prev,
+        "incidents_pct": pct(incidents_curr, incidents_prev),
+        "current_year": CURRENT_YEAR,
+        "prev_year": PREV_YEAR,
+    }

--- a/app/data.py
+++ b/app/data.py
@@ -10,7 +10,7 @@ THREE11 = "read_csv_auto('data/clean/311_data_part_*.csv.gz')"
 # 311 ward values are mixed strings ('1', '1.0') — normalize to integer
 _311_WARD = "TRY_CAST(TRY_CAST(ward AS DOUBLE) AS INTEGER)"
 
-WARDS = list(range(1, 9))
+WARDS = [str(w) for w in range(1, 9)]
 CURRENT_YEAR = 2024
 PREV_YEAR = 2023
 
@@ -24,7 +24,7 @@ def _geo_filter(geo_type: str | None, geo_id: str | None) -> str:
     if not geo_type or not geo_id:
         return ""
     if geo_type == "ward":
-        return f"AND ward = {int(geo_id)}"
+        return f"AND ward = {geo_id}"
     if geo_type == "anc":
         return f"AND anc_id = '{geo_id}'"
     if geo_type == "smd":
@@ -86,7 +86,7 @@ def arrests_yoy(geo_type=None, geo_id=None) -> list[dict]:
 
 def arrests_by_ward(year=CURRENT_YEAR) -> list[dict]:
     rows = _con().execute(f"""
-        SELECT ward, COUNT(*) AS arrests
+        SELECT CAST(ward AS VARCHAR) AS ward, COUNT(*) AS arrests
         FROM {ARRESTS}
         WHERE year = {year} AND ward IS NOT NULL
         GROUP BY ward ORDER BY ward
@@ -115,8 +115,8 @@ def available_smds(anc_id: str) -> list[str]:
 
 # ── Incidents ─────────────────────────────────────────────────────────────────
 
-def incidents_by_year(ward: int | None = None) -> list[dict]:
-    geo = f"AND ward = {ward}" if ward else ""
+def incidents_by_year(ward: str | None = None) -> list[dict]:
+    geo = f"AND CAST(ward AS INTEGER) = {ward}" if ward else ""
     rows = _con().execute(f"""
         SELECT year, COUNT(*) AS incidents
         FROM {INCIDENTS}
@@ -126,8 +126,8 @@ def incidents_by_year(ward: int | None = None) -> list[dict]:
     return [{"year": r[0], "incidents": r[1]} for r in rows]
 
 
-def incidents_by_offense(year=CURRENT_YEAR, ward: int | None = None) -> list[dict]:
-    geo = f"AND ward = {ward}" if ward else ""
+def incidents_by_offense(year=CURRENT_YEAR, ward: str | None = None) -> list[dict]:
+    geo = f"AND CAST(ward AS INTEGER) = {ward}" if ward else ""
     rows = _con().execute(f"""
         SELECT offense, COUNT(*) AS incidents
         FROM {INCIDENTS}
@@ -140,11 +140,11 @@ def incidents_by_offense(year=CURRENT_YEAR, ward: int | None = None) -> list[dic
 
 # ── 311 Service Requests ──────────────────────────────────────────────────────
 
-def _311_ward_filter(ward: int | None) -> str:
+def _311_ward_filter(ward: str | None) -> str:
     return f"AND {_311_WARD} = {ward}" if ward else ""
 
 
-def requests_by_year(ward: int | None = None) -> list[dict]:
+def requests_by_year(ward: str | None = None) -> list[dict]:
     geo = _311_ward_filter(ward)
     rows = _con().execute(f"""
         SELECT YEAR(ADDDATE) AS year, COUNT(*) AS requests
@@ -155,7 +155,7 @@ def requests_by_year(ward: int | None = None) -> list[dict]:
     return [{"year": r[0], "requests": r[1]} for r in rows]
 
 
-def requests_by_service(year=CURRENT_YEAR, ward: int | None = None) -> list[dict]:
+def requests_by_service(year=CURRENT_YEAR, ward: str | None = None) -> list[dict]:
     geo = _311_ward_filter(ward)
     rows = _con().execute(f"""
         SELECT SERVICECODEDESCRIPTION AS service, COUNT(*) AS requests
@@ -168,7 +168,7 @@ def requests_by_service(year=CURRENT_YEAR, ward: int | None = None) -> list[dict
     return [{"service": r[0], "requests": r[1]} for r in rows]
 
 
-def requests_by_agency(year=CURRENT_YEAR, ward: int | None = None) -> list[dict]:
+def requests_by_agency(year=CURRENT_YEAR, ward: str | None = None) -> list[dict]:
     geo = _311_ward_filter(ward)
     rows = _con().execute(f"""
         SELECT ORGANIZATIONACRONYM AS agency, COUNT(*) AS requests
@@ -183,7 +183,7 @@ def requests_by_agency(year=CURRENT_YEAR, ward: int | None = None) -> list[dict]
 
 def requests_by_ward(year=CURRENT_YEAR) -> list[dict]:
     rows = _con().execute(f"""
-        SELECT {_311_WARD} AS ward, COUNT(*) AS requests
+        SELECT CAST({_311_WARD} AS VARCHAR) AS ward, COUNT(*) AS requests
         FROM {THREE11}
         WHERE YEAR(ADDDATE) = {year}
           AND {_311_WARD} BETWEEN 1 AND 8
@@ -192,7 +192,7 @@ def requests_by_ward(year=CURRENT_YEAR) -> list[dict]:
     return [{"ward": r[0], "requests": r[1]} for r in rows]
 
 
-def requests_yoy(ward: int | None = None) -> list[dict]:
+def requests_yoy(ward: str | None = None) -> list[dict]:
     geo = _311_ward_filter(ward)
     rows = _con().execute(f"""
         WITH base AS (
@@ -218,7 +218,7 @@ def requests_yoy(ward: int | None = None) -> list[dict]:
     ]
 
 
-def requests_status_summary(year=CURRENT_YEAR, ward: int | None = None) -> list[dict]:
+def requests_status_summary(year=CURRENT_YEAR, ward: str | None = None) -> list[dict]:
     """Normalize the messy status variants into Closed / Open / Other."""
     geo = _311_ward_filter(ward)
     rows = _con().execute(f"""

--- a/app/data.py
+++ b/app/data.py
@@ -5,6 +5,10 @@ import duckdb
 ARRESTS = "read_csv_auto('data/clean/arrest_data.csv.gz')"
 INCIDENTS = "read_csv_auto('data/clean/incident_data_all.csv.gz')"
 STOPS = "read_csv_auto('data/clean/stop_data.csv.gz')"
+THREE11 = "read_csv_auto('data/clean/311_data_part_*.csv.gz')"
+
+# 311 ward values are mixed strings ('1', '1.0') — normalize to integer
+_311_WARD = "TRY_CAST(TRY_CAST(ward AS DOUBLE) AS INTEGER)"
 
 WARDS = list(range(1, 9))
 CURRENT_YEAR = 2024
@@ -134,6 +138,107 @@ def incidents_by_offense(year=CURRENT_YEAR, ward: int | None = None) -> list[dic
     return [{"offense": r[0], "incidents": r[1]} for r in rows]
 
 
+# ── 311 Service Requests ──────────────────────────────────────────────────────
+
+def _311_ward_filter(ward: int | None) -> str:
+    return f"AND {_311_WARD} = {ward}" if ward else ""
+
+
+def requests_by_year(ward: int | None = None) -> list[dict]:
+    geo = _311_ward_filter(ward)
+    rows = _con().execute(f"""
+        SELECT YEAR(ADDDATE) AS year, COUNT(*) AS requests
+        FROM {THREE11}
+        WHERE ADDDATE IS NOT NULL {geo}
+        GROUP BY year ORDER BY year
+    """).fetchall()
+    return [{"year": r[0], "requests": r[1]} for r in rows]
+
+
+def requests_by_service(year=CURRENT_YEAR, ward: int | None = None) -> list[dict]:
+    geo = _311_ward_filter(ward)
+    rows = _con().execute(f"""
+        SELECT SERVICECODEDESCRIPTION AS service, COUNT(*) AS requests
+        FROM {THREE11}
+        WHERE YEAR(ADDDATE) = {year}
+          AND SERVICECODEDESCRIPTION IS NOT NULL {geo}
+        GROUP BY service ORDER BY requests DESC
+        LIMIT 15
+    """).fetchall()
+    return [{"service": r[0], "requests": r[1]} for r in rows]
+
+
+def requests_by_agency(year=CURRENT_YEAR, ward: int | None = None) -> list[dict]:
+    geo = _311_ward_filter(ward)
+    rows = _con().execute(f"""
+        SELECT ORGANIZATIONACRONYM AS agency, COUNT(*) AS requests
+        FROM {THREE11}
+        WHERE YEAR(ADDDATE) = {year}
+          AND ORGANIZATIONACRONYM IS NOT NULL {geo}
+        GROUP BY agency ORDER BY requests DESC
+        LIMIT 10
+    """).fetchall()
+    return [{"agency": r[0], "requests": r[1]} for r in rows]
+
+
+def requests_by_ward(year=CURRENT_YEAR) -> list[dict]:
+    rows = _con().execute(f"""
+        SELECT {_311_WARD} AS ward, COUNT(*) AS requests
+        FROM {THREE11}
+        WHERE YEAR(ADDDATE) = {year}
+          AND {_311_WARD} BETWEEN 1 AND 8
+        GROUP BY ward ORDER BY ward
+    """).fetchall()
+    return [{"ward": r[0], "requests": r[1]} for r in rows]
+
+
+def requests_yoy(ward: int | None = None) -> list[dict]:
+    geo = _311_ward_filter(ward)
+    rows = _con().execute(f"""
+        WITH base AS (
+            SELECT SERVICECODEDESCRIPTION AS service,
+                COUNT(*) FILTER (WHERE YEAR(ADDDATE) = {PREV_YEAR}) AS prev,
+                COUNT(*) FILTER (WHERE YEAR(ADDDATE) = {CURRENT_YEAR}) AS curr
+            FROM {THREE11}
+            WHERE YEAR(ADDDATE) IN ({PREV_YEAR}, {CURRENT_YEAR})
+              AND SERVICECODEDESCRIPTION IS NOT NULL {geo}
+            GROUP BY service
+        )
+        SELECT service, prev, curr,
+               curr - prev AS change,
+               ROUND(100.0 * (curr - prev) / NULLIF(prev, 0), 1) AS pct_change
+        FROM base
+        WHERE prev > 0 OR curr > 0
+        ORDER BY curr DESC
+        LIMIT 20
+    """).fetchall()
+    return [
+        {"service": r[0], "prev": r[1], "curr": r[2], "change": r[3], "pct_change": r[4]}
+        for r in rows
+    ]
+
+
+def requests_status_summary(year=CURRENT_YEAR, ward: int | None = None) -> list[dict]:
+    """Normalize the messy status variants into Closed / Open / Other."""
+    geo = _311_ward_filter(ward)
+    rows = _con().execute(f"""
+        SELECT
+            CASE
+                WHEN UPPER(SERVICEORDERSTATUS) LIKE 'CLOSED%' THEN 'Closed'
+                WHEN UPPER(SERVICEORDERSTATUS) LIKE 'OPEN%'   THEN 'Open'
+                WHEN UPPER(SERVICEORDERSTATUS) LIKE 'IN-PROG%'
+                  OR UPPER(SERVICEORDERSTATUS) LIKE 'IN PROG%' THEN 'In Progress'
+                WHEN UPPER(SERVICEORDERSTATUS) LIKE 'CANCEL%' THEN 'Canceled'
+                ELSE 'Other'
+            END AS status,
+            COUNT(*) AS requests
+        FROM {THREE11}
+        WHERE YEAR(ADDDATE) = {year} {geo}
+        GROUP BY status ORDER BY requests DESC
+    """).fetchall()
+    return [{"status": r[0], "requests": r[1]} for r in rows]
+
+
 # ── Summary stats for front page ──────────────────────────────────────────────
 
 def citywide_summary() -> dict:
@@ -142,6 +247,8 @@ def citywide_summary() -> dict:
     arrests_prev = con.execute(f"SELECT COUNT(*) FROM {ARRESTS} WHERE year = {PREV_YEAR}").fetchone()[0]
     incidents_curr = con.execute(f"SELECT COUNT(*) FROM {INCIDENTS} WHERE year = {CURRENT_YEAR}").fetchone()[0]
     incidents_prev = con.execute(f"SELECT COUNT(*) FROM {INCIDENTS} WHERE year = {PREV_YEAR}").fetchone()[0]
+    req_curr = con.execute(f"SELECT COUNT(*) FROM {THREE11} WHERE YEAR(ADDDATE) = {CURRENT_YEAR}").fetchone()[0]
+    req_prev = con.execute(f"SELECT COUNT(*) FROM {THREE11} WHERE YEAR(ADDDATE) = {PREV_YEAR}").fetchone()[0]
 
     def pct(curr, prev):
         return round(100 * (curr - prev) / prev, 1) if prev else 0
@@ -153,6 +260,9 @@ def citywide_summary() -> dict:
         "incidents_curr": incidents_curr,
         "incidents_prev": incidents_prev,
         "incidents_pct": pct(incidents_curr, incidents_prev),
+        "req_curr": req_curr,
+        "req_prev": req_prev,
+        "req_pct": pct(req_curr, req_prev),
         "current_year": CURRENT_YEAR,
         "prev_year": PREV_YEAR,
     }

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from app import data
+from app.routers import arrests, incidents
+
+app = FastAPI(title="DC Public Data")
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
+app.include_router(arrests.router)
+app.include_router(incidents.router)
+
+templates = Jinja2Templates(directory="app/templates")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    summary = data.citywide_summary()
+    return templates.TemplateResponse("index.html", {"request": request, "summary": summary})

--- a/app/main.py
+++ b/app/main.py
@@ -4,12 +4,13 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from app import data
-from app.routers import arrests, incidents
+from app.routers import arrests, incidents, service_311
 
 app = FastAPI(title="DC Public Data")
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 app.include_router(arrests.router)
 app.include_router(incidents.router)
+app.include_router(service_311.router)
 
 templates = Jinja2Templates(directory="app/templates")
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,13 +4,14 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from app import data
-from app.routers import arrests, incidents, service_311
+from app.routers import arrests, incidents, service_311, stops
 
 app = FastAPI(title="DC Public Data")
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 app.include_router(arrests.router)
 app.include_router(incidents.router)
 app.include_router(service_311.router)
+app.include_router(stops.router)
 
 templates = Jinja2Templates(directory="app/templates")
 

--- a/app/routers/arrests.py
+++ b/app/routers/arrests.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from app import data
+
+router = APIRouter(prefix="/arrests", tags=["arrests"])
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/", response_class=HTMLResponse)
+async def arrests_index(
+    request: Request,
+    geo_type: str | None = None,
+    geo_id: str | None = None,
+    year: int = data.CURRENT_YEAR,
+):
+    by_year = data.arrests_by_year(geo_type, geo_id)
+    by_category = data.arrests_by_category(year, geo_type, geo_id)
+    yoy = data.arrests_yoy(geo_type, geo_id)
+    by_ward = data.arrests_by_ward(year)
+    ancs = data.available_ancs()
+
+    geo_label = f"{geo_type.upper()} {geo_id}" if geo_type and geo_id else "Citywide"
+
+    return templates.TemplateResponse("arrests/index.html", {
+        "request": request,
+        "geo_label": geo_label,
+        "geo_type": geo_type,
+        "geo_id": geo_id,
+        "year": year,
+        "by_year": by_year,
+        "by_category": by_category,
+        "yoy": yoy,
+        "by_ward": by_ward,
+        "ancs": ancs,
+        "wards": data.WARDS,
+        "current_year": data.CURRENT_YEAR,
+        "prev_year": data.PREV_YEAR,
+    })

--- a/app/routers/incidents.py
+++ b/app/routers/incidents.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from app import data
+
+router = APIRouter(prefix="/incidents", tags=["incidents"])
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/", response_class=HTMLResponse)
+async def incidents_index(
+    request: Request,
+    ward: int | None = None,
+    year: int = data.CURRENT_YEAR,
+):
+    by_year = data.incidents_by_year(ward)
+    by_offense = data.incidents_by_offense(year, ward)
+
+    geo_label = f"Ward {ward}" if ward else "Citywide"
+
+    return templates.TemplateResponse("incidents/index.html", {
+        "request": request,
+        "geo_label": geo_label,
+        "ward": ward,
+        "year": year,
+        "by_year": by_year,
+        "by_offense": by_offense,
+        "wards": data.WARDS,
+        "current_year": data.CURRENT_YEAR,
+        "prev_year": data.PREV_YEAR,
+    })

--- a/app/routers/incidents.py
+++ b/app/routers/incidents.py
@@ -11,7 +11,7 @@ templates = Jinja2Templates(directory="app/templates")
 @router.get("/", response_class=HTMLResponse)
 async def incidents_index(
     request: Request,
-    ward: int | None = None,
+    ward: str | None = None,
     year: int = data.CURRENT_YEAR,
 ):
     by_year = data.incidents_by_year(ward)

--- a/app/routers/service_311.py
+++ b/app/routers/service_311.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from app import data
+
+router = APIRouter(prefix="/311", tags=["311"])
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/", response_class=HTMLResponse)
+async def service_311_index(
+    request: Request,
+    ward: int | None = None,
+    year: int = data.CURRENT_YEAR,
+):
+    by_year = data.requests_by_year(ward)
+    by_service = data.requests_by_service(year, ward)
+    by_agency = data.requests_by_agency(year, ward)
+    by_ward = data.requests_by_ward(year)
+    yoy = data.requests_yoy(ward)
+    status = data.requests_status_summary(year, ward)
+
+    geo_label = f"Ward {ward}" if ward else "Citywide"
+
+    return templates.TemplateResponse("service_311/index.html", {
+        "request": request,
+        "geo_label": geo_label,
+        "ward": ward,
+        "year": year,
+        "by_year": by_year,
+        "by_service": by_service,
+        "by_agency": by_agency,
+        "by_ward": by_ward,
+        "yoy": yoy,
+        "status": status,
+        "wards": data.WARDS,
+        "current_year": data.CURRENT_YEAR,
+        "prev_year": data.PREV_YEAR,
+    })

--- a/app/routers/service_311.py
+++ b/app/routers/service_311.py
@@ -11,7 +11,7 @@ templates = Jinja2Templates(directory="app/templates")
 @router.get("/", response_class=HTMLResponse)
 async def service_311_index(
     request: Request,
-    ward: int | None = None,
+    ward: str | None = None,
     year: int = data.CURRENT_YEAR,
 ):
     by_year = data.requests_by_year(ward)

--- a/app/routers/stops.py
+++ b/app/routers/stops.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from app import data
+
+router = APIRouter(prefix="/stops", tags=["stops"])
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/", response_class=HTMLResponse)
+async def stops_index(
+    request: Request,
+    district: str | None = None,
+    year: int = data.STOPS_CURRENT_YEAR,
+):
+    by_year = data.stops_by_year(district)
+    by_district = data.stops_by_district(year)
+    by_type = data.stops_by_type(year, district)
+    by_ethnicity = data.stops_by_ethnicity(year, district)
+    by_gender = data.stops_by_gender(year, district)
+    search_summary = data.stops_search_summary(year, district)
+    search_by_ethnicity = data.stops_search_by_ethnicity(year, district)
+
+    geo_label = f"District {district}" if district else "Citywide"
+
+    return templates.TemplateResponse("stops/index.html", {
+        "request": request,
+        "geo_label": geo_label,
+        "district": district,
+        "year": year,
+        "by_year": by_year,
+        "by_district": by_district,
+        "by_type": by_type,
+        "by_ethnicity": by_ethnicity,
+        "by_gender": by_gender,
+        "search_summary": search_summary,
+        "search_by_ethnicity": search_by_ethnicity,
+        "districts": data.DISTRICTS,
+        "current_year": data.STOPS_CURRENT_YEAR,
+    })

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1,0 +1,263 @@
+/* ── Reset & base ─────────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --blue: #2563eb;
+  --blue-dark: #1d4ed8;
+  --purple: #7c3aed;
+  --green: #059669;
+  --red: #dc2626;
+  --gray-50: #f9fafb;
+  --gray-100: #f3f4f6;
+  --gray-200: #e5e7eb;
+  --gray-400: #9ca3af;
+  --gray-600: #4b5563;
+  --gray-900: #111827;
+  --up: #dc2626;
+  --down: #059669;
+  --max-width: 1200px;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--gray-900);
+  background: var(--gray-50);
+  line-height: 1.5;
+}
+
+a { color: var(--blue); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ── Nav ──────────────────────────────────────────────────────────────────── */
+header {
+  background: var(--gray-900);
+  color: white;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+nav {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  height: 56px;
+}
+
+.site-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: white;
+  white-space: nowrap;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 0.25rem;
+}
+
+nav ul a {
+  color: var(--gray-400);
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  transition: color 0.15s, background 0.15s;
+}
+
+nav ul a:hover, nav ul a.active {
+  color: white;
+  background: rgba(255,255,255,0.1);
+  text-decoration: none;
+}
+
+/* ── Main layout ──────────────────────────────────────────────────────────── */
+main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 1.5rem;
+  color: var(--gray-600);
+  font-size: 0.875rem;
+  border-top: 1px solid var(--gray-200);
+  margin-top: 3rem;
+}
+
+/* ── Home page ────────────────────────────────────────────────────────────── */
+.hero {
+  margin-bottom: 2.5rem;
+}
+
+.hero h1 {
+  font-size: 2rem;
+  font-weight: 800;
+  margin-bottom: 0.75rem;
+}
+
+.hero p {
+  color: var(--gray-600);
+  max-width: 680px;
+  font-size: 1.05rem;
+}
+
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.card {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 12px;
+  padding: 1.75rem;
+}
+
+.card h2 { font-size: 1rem; color: var(--gray-600); margin-bottom: 0.75rem; }
+
+.stat {
+  font-size: 2.5rem;
+  font-weight: 800;
+  line-height: 1;
+  margin-bottom: 0.25rem;
+}
+
+.stat-label { font-size: 0.875rem; color: var(--gray-600); margin-bottom: 0.5rem; }
+
+.stat-change { font-size: 0.875rem; font-weight: 600; margin-bottom: 1.25rem; }
+.stat-change.up { color: var(--up); }
+.stat-change.down { color: var(--down); }
+
+.about { max-width: 680px; }
+.about h2 { font-size: 1.25rem; margin-bottom: 0.75rem; }
+.about p { color: var(--gray-600); margin-bottom: 0.75rem; }
+
+/* ── Buttons ──────────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-block;
+  background: var(--blue);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  transition: background 0.15s;
+}
+.btn:hover { background: var(--blue-dark); text-decoration: none; }
+
+.btn-secondary {
+  display: inline-block;
+  background: var(--gray-100);
+  color: var(--gray-900);
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid var(--gray-200);
+}
+.btn-secondary:hover { background: var(--gray-200); text-decoration: none; }
+
+/* ── Page header & filters ────────────────────────────────────────────────── */
+.page-header {
+  margin-bottom: 2rem;
+}
+
+.page-header h1 {
+  font-size: 1.75rem;
+  font-weight: 800;
+  margin-bottom: 1rem;
+}
+
+.geo-filter {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.geo-filter label {
+  font-size: 0.875rem;
+  color: var(--gray-600);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.geo-filter select {
+  padding: 0.4rem 0.75rem;
+  border: 1px solid var(--gray-200);
+  border-radius: 6px;
+  background: white;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+/* ── Charts grid ──────────────────────────────────────────────────────────── */
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.chart-card {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.chart-card.wide {
+  grid-column: 1 / -1;
+}
+
+.chart-card h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: var(--gray-600);
+}
+
+.chart-card > div { min-height: 300px; }
+
+/* ── Data table ───────────────────────────────────────────────────────────── */
+.data-table {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  overflow-x: auto;
+}
+
+.data-table h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--gray-600);
+  margin-bottom: 1rem;
+}
+
+table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+th { text-align: left; padding: 0.6rem 1rem; border-bottom: 2px solid var(--gray-200); font-weight: 600; color: var(--gray-600); white-space: nowrap; }
+td { padding: 0.6rem 1rem; border-bottom: 1px solid var(--gray-100); }
+tr:last-child td { border-bottom: none; }
+tr:hover td { background: var(--gray-50); }
+
+td.up { color: var(--up); font-weight: 600; }
+td.down { color: var(--down); font-weight: 600; }
+th:not(:first-child), td:not(:first-child) { text-align: right; }
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .charts-grid { grid-template-columns: 1fr; }
+  .chart-card.wide { grid-column: 1; }
+  .hero h1 { font-size: 1.5rem; }
+}

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -255,6 +255,28 @@ td.up { color: var(--up); font-weight: 600; }
 td.down { color: var(--down); font-weight: 600; }
 th:not(:first-child), td:not(:first-child) { text-align: right; }
 
+/* ── Page notes ───────────────────────────────────────────────────────────── */
+.page-note { color: var(--gray-600); font-size: 0.875rem; margin-top: -0.5rem; margin-bottom: 1rem; }
+.chart-note { color: var(--gray-400); font-size: 0.8rem; margin-top: -0.5rem; margin-bottom: 0.5rem; }
+
+/* ── Stat row (stops summary) ─────────────────────────────────────────────── */
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.stat-box {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+}
+
+.stat-box .stat { font-size: 2rem; font-weight: 800; line-height: 1; margin-bottom: 0.25rem; }
+.stat-box .stat-label { font-size: 0.875rem; color: var(--gray-600); }
+
 /* ── Responsive ───────────────────────────────────────────────────────────── */
 @media (max-width: 768px) {
   .charts-grid { grid-template-columns: 1fr; }

--- a/app/templates/arrests/index.html
+++ b/app/templates/arrests/index.html
@@ -1,0 +1,148 @@
+{% extends "base.html" %}
+{% block title %}Arrests — {{ geo_label }}{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Adult Arrests — {{ geo_label }}</h1>
+
+  <form class="geo-filter" method="get" action="/arrests/">
+    <label>Ward:
+      <select name="geo_id" onchange="this.form.elements['geo_type'].value='ward'; this.form.submit()">
+        <option value="">All wards</option>
+        {% for w in wards %}
+        <option value="{{ w }}" {% if geo_type == 'ward' and geo_id == w|string %}selected{% endif %}>Ward {{ w }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>ANC:
+      <select name="geo_id" onchange="this.form.elements['geo_type'].value='anc'; this.form.submit()">
+        <option value="">All ANCs</option>
+        {% for anc in ancs %}
+        <option value="{{ anc }}" {% if geo_type == 'anc' and geo_id == anc %}selected{% endif %}>ANC {{ anc }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <input type="hidden" name="geo_type" value="{{ geo_type or '' }}">
+    {% if geo_type or geo_id %}
+    <a href="/arrests/" class="btn-secondary">Clear filter</a>
+    {% endif %}
+  </form>
+</div>
+
+<div class="charts-grid">
+  <div class="chart-card wide">
+    <h2>Arrests by Year</h2>
+    <div id="chart-by-year"></div>
+  </div>
+
+  <div class="chart-card">
+    <h2>Top Categories — {{ current_year }}</h2>
+    <div id="chart-by-category"></div>
+  </div>
+
+  <div class="chart-card">
+    <h2>{{ prev_year }} vs {{ current_year }} by Category</h2>
+    <div id="chart-yoy"></div>
+  </div>
+
+  {% if not geo_type %}
+  <div class="chart-card wide">
+    <h2>Arrests by Ward — {{ current_year }}</h2>
+    <div id="chart-by-ward"></div>
+  </div>
+  {% endif %}
+</div>
+
+<section class="data-table">
+  <h2>{{ prev_year }} vs {{ current_year }} Breakdown</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>{{ prev_year }}</th>
+        <th>{{ current_year }}</th>
+        <th>Change</th>
+        <th>% Change</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in yoy %}
+      <tr>
+        <td>{{ row.category }}</td>
+        <td>{{ "{:,}".format(row.prev) }}</td>
+        <td>{{ "{:,}".format(row.curr) }}</td>
+        <td class="{% if row.change > 0 %}up{% elif row.change < 0 %}down{% endif %}">
+          {% if row.change > 0 %}+{% endif %}{{ "{:,}".format(row.change) }}
+        </td>
+        <td class="{% if row.pct_change and row.pct_change > 0 %}up{% elif row.pct_change and row.pct_change < 0 %}down{% endif %}">
+          {% if row.pct_change %}
+            {% if row.pct_change > 0 %}+{% endif %}{{ row.pct_change }}%
+          {% else %}—{% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+
+<script>
+const byYear = {{ by_year | tojson }};
+const byCategory = {{ by_category | tojson }};
+const yoy = {{ yoy | tojson }};
+const byWard = {{ by_ward | tojson }};
+
+Plotly.newPlot('chart-by-year', [{
+  x: byYear.map(d => d.year),
+  y: byYear.map(d => d.arrests),
+  type: 'bar',
+  marker: { color: '#2563eb' }
+}], {
+  margin: { t: 10, r: 10, b: 40, l: 50 },
+  xaxis: { title: '' },
+  yaxis: { title: 'Arrests' },
+  paper_bgcolor: 'transparent',
+  plot_bgcolor: 'transparent'
+});
+
+Plotly.newPlot('chart-by-category', [{
+  x: byCategory.map(d => d.arrests),
+  y: byCategory.map(d => d.category),
+  type: 'bar',
+  orientation: 'h',
+  marker: { color: '#7c3aed' }
+}], {
+  margin: { t: 10, r: 20, b: 40, l: 180 },
+  xaxis: { title: 'Arrests' },
+  yaxis: { automargin: true },
+  paper_bgcolor: 'transparent',
+  plot_bgcolor: 'transparent'
+});
+
+Plotly.newPlot('chart-yoy', [
+  { name: '{{ prev_year }}', x: yoy.map(d => d.prev), y: yoy.map(d => d.category), type: 'bar', orientation: 'h', marker: { color: '#9ca3af' } },
+  { name: '{{ current_year }}', x: yoy.map(d => d.curr), y: yoy.map(d => d.category), type: 'bar', orientation: 'h', marker: { color: '#2563eb' } }
+], {
+  barmode: 'group',
+  margin: { t: 10, r: 20, b: 40, l: 180 },
+  xaxis: { title: 'Arrests' },
+  yaxis: { automargin: true },
+  paper_bgcolor: 'transparent',
+  plot_bgcolor: 'transparent'
+});
+
+{% if not geo_type %}
+Plotly.newPlot('chart-by-ward', [{
+  x: byWard.map(d => 'Ward ' + d.ward),
+  y: byWard.map(d => d.arrests),
+  type: 'bar',
+  marker: { color: '#059669' }
+}], {
+  margin: { t: 10, r: 10, b: 40, l: 60 },
+  xaxis: { title: '' },
+  yaxis: { title: 'Arrests' },
+  paper_bgcolor: 'transparent',
+  plot_bgcolor: 'transparent'
+});
+{% endif %}
+</script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}DC Public Data{% endblock %}</title>
+  <link rel="stylesheet" href="/static/css/style.css">
+  <script src="https://cdn.plot.ly/plotly-3.0.0.min.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="/" class="site-title">DC Public Data</a>
+      <ul>
+        <li><a href="/arrests/">Arrests</a></li>
+        <li><a href="/incidents/">Crime Incidents</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer>
+    <p>Data sourced from <a href="https://opendata.dc.gov" target="_blank">DC Open Data</a> and the <a href="https://mpdc.dc.gov" target="_blank">Metropolitan Police Department</a>.</p>
+  </footer>
+</body>
+</html>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,6 +17,7 @@
         <li><a href="/arrests/">Arrests</a></li>
         <li><a href="/incidents/">Crime Incidents</a></li>
         <li><a href="/311/">311 Requests</a></li>
+        <li><a href="/stops/">Police Stops</a></li>
       </ul>
     </nav>
   </header>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,6 +16,7 @@
       <ul>
         <li><a href="/arrests/">Arrests</a></li>
         <li><a href="/incidents/">Crime Incidents</a></li>
+        <li><a href="/311/">311 Requests</a></li>
       </ul>
     </nav>
   </header>

--- a/app/templates/incidents/index.html
+++ b/app/templates/incidents/index.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% block title %}Crime Incidents — {{ geo_label }}{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Crime Incidents — {{ geo_label }}</h1>
+
+  <form class="geo-filter" method="get" action="/incidents/">
+    <label>Ward:
+      <select name="ward" onchange="this.form.submit()">
+        <option value="">All wards</option>
+        {% for w in wards %}
+        <option value="{{ w }}" {% if ward == w %}selected{% endif %}>Ward {{ w }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% if ward %}
+    <a href="/incidents/" class="btn-secondary">Clear filter</a>
+    {% endif %}
+  </form>
+</div>
+
+<div class="charts-grid">
+  <div class="chart-card wide">
+    <h2>Incidents by Year</h2>
+    <div id="chart-by-year"></div>
+  </div>
+
+  <div class="chart-card wide">
+    <h2>Incidents by Offense Type — {{ current_year }}</h2>
+    <div id="chart-by-offense"></div>
+  </div>
+</div>
+
+<section class="data-table">
+  <h2>Top Offenses — {{ current_year }}</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Offense</th>
+        <th>Incidents</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in by_offense %}
+      <tr>
+        <td>{{ row.offense | title }}</td>
+        <td>{{ "{:,}".format(row.incidents) }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+
+<script>
+const byYear = {{ by_year | tojson }};
+const byOffense = {{ by_offense | tojson }};
+
+Plotly.newPlot('chart-by-year', [{
+  x: byYear.map(d => d.year),
+  y: byYear.map(d => d.incidents),
+  type: 'bar',
+  marker: { color: '#dc2626' }
+}], {
+  margin: { t: 10, r: 10, b: 40, l: 60 },
+  yaxis: { title: 'Incidents' },
+  paper_bgcolor: 'transparent',
+  plot_bgcolor: 'transparent'
+});
+
+Plotly.newPlot('chart-by-offense', [{
+  x: byOffense.map(d => d.incidents),
+  y: byOffense.map(d => d.offense.replace(/\b\w/g, l => l.toUpperCase())),
+  type: 'bar',
+  orientation: 'h',
+  marker: { color: '#dc2626' }
+}], {
+  margin: { t: 10, r: 20, b: 40, l: 180 },
+  xaxis: { title: 'Incidents' },
+  yaxis: { automargin: true },
+  paper_bgcolor: 'transparent',
+  plot_bgcolor: 'transparent'
+});
+</script>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -27,6 +27,16 @@
     </div>
     <a href="/incidents/" class="btn">Explore incidents →</a>
   </div>
+
+  <div class="card">
+    <h2>311 Service Requests</h2>
+    <div class="stat">{{ "{:,}".format(summary.req_curr) }}</div>
+    <div class="stat-label">{{ summary.current_year }} total</div>
+    <div class="stat-change {% if summary.req_pct > 0 %}up{% elif summary.req_pct < 0 %}down{% endif %}">
+      {% if summary.req_pct > 0 %}+{% endif %}{{ summary.req_pct }}% vs {{ summary.prev_year }}
+    </div>
+    <a href="/311/" class="btn">Explore 311 →</a>
+  </div>
 </section>
 
 <section class="about">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}DC Public Data — Home{% endblock %}
+
+{% block content %}
+<div class="hero">
+  <h1>Washington DC Public Safety Data</h1>
+  <p>Explore arrests, crime incidents, police stops, and 311 service requests for Washington, DC. Browse citywide trends or filter by Ward, ANC, or Single Member District.</p>
+</div>
+
+<section class="summary-cards">
+  <div class="card">
+    <h2>Arrests</h2>
+    <div class="stat">{{ "{:,}".format(summary.arrests_curr) }}</div>
+    <div class="stat-label">{{ summary.current_year }} total</div>
+    <div class="stat-change {% if summary.arrests_pct > 0 %}up{% elif summary.arrests_pct < 0 %}down{% endif %}">
+      {% if summary.arrests_pct > 0 %}+{% endif %}{{ summary.arrests_pct }}% vs {{ summary.prev_year }}
+    </div>
+    <a href="/arrests/" class="btn">Explore arrests →</a>
+  </div>
+
+  <div class="card">
+    <h2>Crime Incidents</h2>
+    <div class="stat">{{ "{:,}".format(summary.incidents_curr) }}</div>
+    <div class="stat-label">{{ summary.current_year }} total</div>
+    <div class="stat-change {% if summary.incidents_pct > 0 %}up{% elif summary.incidents_pct < 0 %}down{% endif %}">
+      {% if summary.incidents_pct > 0 %}+{% endif %}{{ summary.incidents_pct }}% vs {{ summary.prev_year }}
+    </div>
+    <a href="/incidents/" class="btn">Explore incidents →</a>
+  </div>
+</section>
+
+<section class="about">
+  <h2>About This Site</h2>
+  <p>All data is sourced from the DC government's open data portal and updated regularly. Browse by topic using the navigation above, or filter any view by ward, ANC, or SMD using the controls on each page.</p>
+  <p>Source code and raw data are available on <a href="https://github.com/taylorterry3/dc-public-data" target="_blank">GitHub</a>.</p>
+</section>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,6 +37,16 @@
     </div>
     <a href="/311/" class="btn">Explore 311 →</a>
   </div>
+
+  <div class="card">
+    <h2>Police Stops</h2>
+    <div class="stat">{{ "{:,}".format(summary.stops_curr) }}</div>
+    <div class="stat-label">{{ summary.stops_year }} total</div>
+    <div class="stat-change {% if summary.stops_pct > 0 %}up{% elif summary.stops_pct < 0 %}down{% endif %}">
+      {% if summary.stops_pct > 0 %}+{% endif %}{{ summary.stops_pct }}% vs {{ summary.prev_year }}
+    </div>
+    <a href="/stops/" class="btn">Explore stops →</a>
+  </div>
 </section>
 
 <section class="about">

--- a/app/templates/service_311/index.html
+++ b/app/templates/service_311/index.html
@@ -1,0 +1,140 @@
+{% extends "base.html" %}
+{% block title %}311 Service Requests — {{ geo_label }}{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>311 Service Requests — {{ geo_label }}</h1>
+
+  <form class="geo-filter" method="get" action="/311/">
+    <label>Ward:
+      <select name="ward" onchange="this.form.submit()">
+        <option value="">All wards</option>
+        {% for w in wards %}
+        <option value="{{ w }}" {% if ward == w %}selected{% endif %}>Ward {{ w }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% if ward %}
+    <a href="/311/" class="btn-secondary">Clear filter</a>
+    {% endif %}
+  </form>
+</div>
+
+<div class="charts-grid">
+  <div class="chart-card wide">
+    <h2>Requests by Year</h2>
+    <div id="chart-by-year"></div>
+  </div>
+
+  <div class="chart-card">
+    <h2>Top Service Types — {{ year }}</h2>
+    <div id="chart-by-service"></div>
+  </div>
+
+  <div class="chart-card">
+    <h2>Requests by Agency — {{ year }}</h2>
+    <div id="chart-by-agency"></div>
+  </div>
+
+  {% if not ward %}
+  <div class="chart-card">
+    <h2>Requests by Ward — {{ year }}</h2>
+    <div id="chart-by-ward"></div>
+  </div>
+  {% endif %}
+
+  <div class="chart-card {% if ward %}wide{% endif %}">
+    <h2>Request Status — {{ year }}</h2>
+    <div id="chart-status"></div>
+  </div>
+</div>
+
+<section class="data-table">
+  <h2>{{ prev_year }} vs {{ current_year }} by Service Type</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Service Type</th>
+        <th>{{ prev_year }}</th>
+        <th>{{ current_year }}</th>
+        <th>Change</th>
+        <th>% Change</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in yoy %}
+      <tr>
+        <td>{{ row.service }}</td>
+        <td>{{ "{:,}".format(row.prev) }}</td>
+        <td>{{ "{:,}".format(row.curr) }}</td>
+        <td class="{% if row.change > 0 %}up{% elif row.change < 0 %}down{% endif %}">
+          {% if row.change > 0 %}+{% endif %}{{ "{:,}".format(row.change) }}
+        </td>
+        <td class="{% if row.pct_change and row.pct_change > 0 %}up{% elif row.pct_change and row.pct_change < 0 %}down{% endif %}">
+          {% if row.pct_change %}
+            {% if row.pct_change > 0 %}+{% endif %}{{ row.pct_change }}%
+          {% else %}—{% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+
+<script>
+const byYear    = {{ by_year    | tojson }};
+const byService = {{ by_service | tojson }};
+const byAgency  = {{ by_agency  | tojson }};
+const byWard    = {{ by_ward    | tojson }};
+const status    = {{ status     | tojson }};
+
+const layout_base = {
+  margin: { t: 10, r: 10, b: 40, l: 50 },
+  paper_bgcolor: 'transparent',
+  plot_bgcolor: 'transparent',
+};
+
+Plotly.newPlot('chart-by-year', [{
+  x: byYear.map(d => d.year),
+  y: byYear.map(d => d.requests),
+  type: 'bar',
+  marker: { color: '#0891b2' },
+}], { ...layout_base, yaxis: { title: 'Requests' } });
+
+Plotly.newPlot('chart-by-service', [{
+  x: byService.map(d => d.requests),
+  y: byService.map(d => d.service),
+  type: 'bar',
+  orientation: 'h',
+  marker: { color: '#0891b2' },
+}], { ...layout_base, margin: { ...layout_base.margin, l: 200 }, xaxis: { title: 'Requests' }, yaxis: { automargin: true } });
+
+Plotly.newPlot('chart-by-agency', [{
+  values: byAgency.map(d => d.requests),
+  labels: byAgency.map(d => d.agency),
+  type: 'pie',
+  hole: 0.4,
+  textinfo: 'label+percent',
+  hoverinfo: 'label+value',
+}], { ...layout_base, margin: { t: 10, r: 10, b: 10, l: 10 }, showlegend: false });
+
+{% if not ward %}
+Plotly.newPlot('chart-by-ward', [{
+  x: byWard.map(d => 'Ward ' + d.ward),
+  y: byWard.map(d => d.requests),
+  type: 'bar',
+  marker: { color: '#0891b2' },
+}], { ...layout_base, yaxis: { title: 'Requests' } });
+{% endif %}
+
+Plotly.newPlot('chart-status', [{
+  values: status.map(d => d.requests),
+  labels: status.map(d => d.status),
+  type: 'pie',
+  hole: 0.4,
+  textinfo: 'label+percent',
+  hoverinfo: 'label+value',
+  marker: { colors: ['#059669', '#2563eb', '#f59e0b', '#9ca3af', '#dc2626'] },
+}], { ...layout_base, margin: { t: 10, r: 10, b: 10, l: 10 }, showlegend: false });
+</script>
+{% endblock %}

--- a/app/templates/stops/index.html
+++ b/app/templates/stops/index.html
@@ -1,0 +1,170 @@
+{% extends "base.html" %}
+{% block title %}Police Stops — {{ geo_label }}{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Police Stops — {{ geo_label }}</h1>
+  <p class="page-note">Data available for 2023–2025. Filtered to complete years where noted.</p>
+
+  <form class="geo-filter" method="get" action="/stops/">
+    <label>District:
+      <select name="district" onchange="this.form.submit()">
+        <option value="">All districts</option>
+        {% for d in districts %}
+        <option value="{{ d }}" {% if district == d %}selected{% endif %}>{{ d }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% if district %}
+    <a href="/stops/" class="btn-secondary">Clear filter</a>
+    {% endif %}
+  </form>
+</div>
+
+<div class="stat-row">
+  <div class="stat-box">
+    <div class="stat">{{ "{:,}".format(search_summary.total) }}</div>
+    <div class="stat-label">Total stops — {{ current_year }}</div>
+  </div>
+  <div class="stat-box">
+    <div class="stat">{{ "{:,}".format(search_summary.searched) }}</div>
+    <div class="stat-label">Persons searched ({{ search_summary.search_rate }}%)</div>
+  </div>
+  <div class="stat-box">
+    <div class="stat">{{ "{:,}".format(search_summary.arrested) }}</div>
+    <div class="stat-label">Resulting in arrest ({{ search_summary.arrest_rate }}%)</div>
+  </div>
+</div>
+
+<div class="charts-grid">
+  <div class="chart-card wide">
+    <h2>Stops by Year</h2>
+    <div id="chart-by-year"></div>
+  </div>
+
+  <div class="chart-card">
+    <h2>Stops by Ethnicity — {{ current_year }}</h2>
+    <div id="chart-by-ethnicity"></div>
+  </div>
+
+  <div class="chart-card">
+    <h2>Stop Type — {{ current_year }}</h2>
+    <div id="chart-by-type"></div>
+  </div>
+
+  <div class="chart-card">
+    <h2>Search Rate by Ethnicity — {{ current_year }}</h2>
+    <p class="chart-note">Groups with fewer than 50 stops excluded.</p>
+    <div id="chart-search-rate"></div>
+  </div>
+
+  <div class="chart-card">
+    <h2>Stops by Gender — {{ current_year }}</h2>
+    <div id="chart-by-gender"></div>
+  </div>
+
+  {% if not district %}
+  <div class="chart-card wide">
+    <h2>Stops by Police District — {{ current_year }}</h2>
+    <div id="chart-by-district"></div>
+  </div>
+  {% endif %}
+</div>
+
+<section class="data-table">
+  <h2>Search Rate by Ethnicity — {{ current_year }}</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Ethnicity</th>
+        <th>Stops</th>
+        <th>Searched</th>
+        <th>Search Rate</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in search_by_ethnicity %}
+      <tr>
+        <td>{{ row.ethnicity }}</td>
+        <td>{{ "{:,}".format(row.stops) }}</td>
+        <td>{{ "{:,}".format(row.searched) }}</td>
+        <td>{{ row.search_rate }}%</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+
+<script>
+const byYear       = {{ by_year            | tojson }};
+const byDistrict   = {{ by_district        | tojson }};
+const byType       = {{ by_type            | tojson }};
+const byEthnicity  = {{ by_ethnicity       | tojson }};
+const byGender     = {{ by_gender          | tojson }};
+const searchByEth  = {{ search_by_ethnicity | tojson }};
+
+const layout_base = {
+  margin: { t: 10, r: 10, b: 40, l: 50 },
+  paper_bgcolor: 'transparent',
+  plot_bgcolor: 'transparent',
+};
+
+Plotly.newPlot('chart-by-year', [{
+  x: byYear.map(d => d.year),
+  y: byYear.map(d => d.stops),
+  type: 'bar',
+  marker: { color: '#7c3aed' },
+}], { ...layout_base, yaxis: { title: 'Stops' } });
+
+Plotly.newPlot('chart-by-ethnicity', [{
+  values: byEthnicity.map(d => d.stops),
+  labels: byEthnicity.map(d => d.ethnicity),
+  type: 'pie',
+  hole: 0.4,
+  textinfo: 'label+percent',
+  hoverinfo: 'label+value',
+}], { ...layout_base, margin: { t: 10, r: 10, b: 10, l: 10 }, showlegend: false });
+
+Plotly.newPlot('chart-by-type', [{
+  values: byType.map(d => d.stops),
+  labels: byType.map(d => d.stop_type),
+  type: 'pie',
+  hole: 0.4,
+  textinfo: 'label+percent',
+  hoverinfo: 'label+value',
+}], { ...layout_base, margin: { t: 10, r: 10, b: 10, l: 10 }, showlegend: false });
+
+Plotly.newPlot('chart-search-rate', [{
+  x: searchByEth.map(d => d.search_rate),
+  y: searchByEth.map(d => d.ethnicity),
+  type: 'bar',
+  orientation: 'h',
+  marker: { color: '#dc2626' },
+  text: searchByEth.map(d => d.search_rate + '%'),
+  textposition: 'outside',
+}], {
+  ...layout_base,
+  margin: { t: 10, r: 60, b: 40, l: 160 },
+  xaxis: { title: 'Search rate (%)', range: [0, Math.max(...searchByEth.map(d => d.search_rate)) * 1.2] },
+  yaxis: { automargin: true },
+});
+
+Plotly.newPlot('chart-by-gender', [{
+  values: byGender.map(d => d.stops),
+  labels: byGender.map(d => d.gender),
+  type: 'pie',
+  hole: 0.4,
+  textinfo: 'label+percent',
+  hoverinfo: 'label+value',
+}], { ...layout_base, margin: { t: 10, r: 10, b: 10, l: 10 }, showlegend: false });
+
+{% if not district %}
+Plotly.newPlot('chart-by-district', [{
+  x: byDistrict.map(d => d.district),
+  y: byDistrict.map(d => d.stops),
+  type: 'bar',
+  marker: { color: '#7c3aed' },
+}], { ...layout_base, yaxis: { title: 'Stops' } });
+{% endif %}
+</script>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,11 @@ description = "ETL, analysis, and reporting for Washington DC public data (polic
 requires-python = ">=3.14"
 dependencies = [
     "click>=8.3.1",
+    "duckdb>=1.4.4",
+    "fastapi>=0.135.1",
     "geopandas>=1.1.2",
     "ipykernel>=7.2.0",
+    "jinja2>=3.1.6",
     "markdown>=3.10.2",
     "markdown2>=2.5.5",
     "matplotlib>=3.10.8",
@@ -23,12 +26,14 @@ dependencies = [
     "pyproj>=3.7.2",
     "pyreadstat>=1.3.3",
     "pytesseract>=0.3.13",
+    "python-multipart>=0.0.22",
     "scikit-learn>=1.8.0",
     "scipy>=1.17.1",
     "seaborn>=0.13.2",
     "shapely>=2.1.2",
     "statsmodels>=0.14.6",
     "tqdm>=4.67.3",
+    "uvicorn>=0.41.0",
     "xgboost>=3.2.0",
 ]
 

--- a/scripts/etl/common.py
+++ b/scripts/etl/common.py
@@ -20,6 +20,32 @@ def data_cleanup(df: pd.DataFrame, date_col: str) -> pd.DataFrame:
     return df
 
 
+def normalize_ward(series: pd.Series) -> pd.Series:
+    """Normalize ward to a clean string '1'-'8', handling floats and None."""
+    return (
+        series
+        .astype(str)
+        .str.replace(r"\.0$", "", regex=True)
+        .str.strip()
+        .where(series.notna(), other=None)
+    )
+
+
+def normalize_district(series: pd.Series) -> pd.Series:
+    """Normalize police district to 'ND' string format ('1D'-'7D').
+
+    Handles numeric floats (1.0 → '1D') and bare integers ('1' → '1D').
+    Values already in 'ND' format are left unchanged.
+    """
+    def _fmt(val):
+        if pd.isna(val):
+            return None
+        s = str(val).strip().replace(".0", "")
+        return s if s.endswith("D") else s + "D"
+
+    return series.apply(_fmt)
+
+
 def arrest_category_cleanup(df: pd.DataFrame) -> pd.DataFrame:
     """Fix corrupted category strings in pre-2017 arrest data.
 

--- a/scripts/etl/incidents.py
+++ b/scripts/etl/incidents.py
@@ -4,7 +4,7 @@ import glob
 import pandas as pd
 from pathlib import Path
 
-from scripts.etl.common import data_cleanup
+from scripts.etl.common import data_cleanup, normalize_district, normalize_ward
 
 RAW_INCIDENTS_GLOB = "data/raw/Crime_Incidents*"
 RAW_INCIDENTS_ALL = Path("data/raw/dc-crimes-search-results.csv")
@@ -32,7 +32,16 @@ def run(
     Returns (incidents_df, incidents_all_df). Pass None for either output path to skip writing.
     """
     incidents = data_cleanup(load_raw_annual(), "START_DATE")
+    if "ward" in incidents.columns:
+        incidents["ward"] = normalize_ward(incidents["ward"])
+    if "district" in incidents.columns:
+        incidents["district"] = normalize_district(incidents["district"])
+
     incidents_all = data_cleanup(load_raw_all(), "START_DATE")
+    if "ward" in incidents_all.columns:
+        incidents_all["ward"] = normalize_ward(incidents_all["ward"])
+    if "district" in incidents_all.columns:
+        incidents_all["district"] = normalize_district(incidents_all["district"])
 
     print(f"Annual incident records: {len(incidents):,}")
     print(f"All-time incident records: {len(incidents_all):,}")

--- a/scripts/etl/service_311.py
+++ b/scripts/etl/service_311.py
@@ -5,6 +5,8 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 
+from scripts.etl.common import normalize_ward
+
 RAW_311_GLOB = "data/raw/311_City_Service_Requests*.csv.gz"
 CLEAN_311_TEMPLATE = "data/clean/311_data_part_{}.csv.gz"
 NUM_PARTS = 3
@@ -23,6 +25,8 @@ def run(output_template: str = CLEAN_311_TEMPLATE, num_parts: int = NUM_PARTS) -
     Returns the combined DataFrame. Pass output_template=None to skip writing.
     """
     df = load_raw()
+    if "WARD" in df.columns:
+        df["WARD"] = normalize_ward(df["WARD"])
     print(f"311 records: {len(df):,}")
 
     if output_template is not None:

--- a/scripts/etl/stops.py
+++ b/scripts/etl/stops.py
@@ -3,7 +3,7 @@
 import pandas as pd
 from pathlib import Path
 
-from scripts.etl.common import data_cleanup
+from scripts.etl.common import data_cleanup, normalize_district
 
 RAW_STOPS_OLD = Path("data/raw/Stop_Data.csv.gz")
 RAW_STOPS_2023_2025 = Path("data/raw/Stop_Data_2023-2025.csv.gz")
@@ -30,6 +30,8 @@ def run(
     df = load_raw(old_path, new_path)
     df = data_cleanup(df, "DATETIME")
     df = df.drop_duplicates(subset="ccn_anonymized")
+    if "stop_district" in df.columns:
+        df["stop_district"] = normalize_district(df["stop_district"])
 
     print(f"Stop records after dedup: {len(df):,}")
 

--- a/tests/unit/test_etl_common.py
+++ b/tests/unit/test_etl_common.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import pytest
 
-from scripts.etl.common import arrest_category_cleanup, data_cleanup
+from scripts.etl.common import arrest_category_cleanup, data_cleanup, normalize_district, normalize_ward
 
 
 class TestDataCleanup:
@@ -88,3 +88,53 @@ class TestArrestCategoryCleanup:
         df = pd.DataFrame({"category": ["Theft", " rcotics", "Assault", "Kid pping"]})
         result = arrest_category_cleanup(df.copy())
         assert result["category"].tolist() == ["Theft", "Narcotics", "Assault", "Kidnapping"]
+
+
+class TestNormalizeWard:
+    def test_integer(self):
+        s = pd.Series([1, 2, 8])
+        assert normalize_ward(s).tolist() == ["1", "2", "8"]
+
+    def test_float_string(self):
+        s = pd.Series(["1.0", "4.0", "8.0"])
+        assert normalize_ward(s).tolist() == ["1", "4", "8"]
+
+    def test_clean_string(self):
+        s = pd.Series(["1", "4", "8"])
+        assert normalize_ward(s).tolist() == ["1", "4", "8"]
+
+    def test_mixed(self):
+        s = pd.Series(["1", "2.0", "3", "4.0"])
+        assert normalize_ward(s).tolist() == ["1", "2", "3", "4"]
+
+    def test_none_preserved(self):
+        s = pd.Series(["1", None, "3"])
+        result = normalize_ward(s)
+        assert result[0] == "1"
+        assert pd.isna(result[1])
+        assert result[2] == "3"
+
+
+class TestNormalizeDistrict:
+    def test_already_formatted(self):
+        s = pd.Series(["1D", "3D", "7D"])
+        assert normalize_district(s).tolist() == ["1D", "3D", "7D"]
+
+    def test_bare_integer_string(self):
+        s = pd.Series(["1", "3", "7"])
+        assert normalize_district(s).tolist() == ["1D", "3D", "7D"]
+
+    def test_float(self):
+        s = pd.Series([1.0, 3.0, 7.0])
+        assert normalize_district(s).tolist() == ["1D", "3D", "7D"]
+
+    def test_mixed(self):
+        s = pd.Series(["1D", "2", "3D", "4"])
+        assert normalize_district(s).tolist() == ["1D", "2D", "3D", "4D"]
+
+    def test_none_preserved(self):
+        s = pd.Series(["1D", None, "3D"])
+        result = normalize_district(s)
+        assert result[0] == "1D"
+        assert pd.isna(result[1])
+        assert result[2] == "3D"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,36 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -232,8 +262,11 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },
+    { name = "duckdb" },
+    { name = "fastapi" },
     { name = "geopandas" },
     { name = "ipykernel" },
+    { name = "jinja2" },
     { name = "markdown" },
     { name = "markdown2" },
     { name = "matplotlib" },
@@ -250,12 +283,14 @@ dependencies = [
     { name = "pyproj" },
     { name = "pyreadstat" },
     { name = "pytesseract" },
+    { name = "python-multipart" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
     { name = "shapely" },
     { name = "statsmodels" },
     { name = "tqdm" },
+    { name = "uvicorn" },
     { name = "xgboost" },
 ]
 
@@ -268,8 +303,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
+    { name = "duckdb", specifier = ">=1.4.4" },
+    { name = "fastapi", specifier = ">=0.135.1" },
     { name = "geopandas", specifier = ">=1.1.2" },
     { name = "ipykernel", specifier = ">=7.2.0" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markdown", specifier = ">=3.10.2" },
     { name = "markdown2", specifier = ">=2.5.5" },
     { name = "matplotlib", specifier = ">=3.10.8" },
@@ -286,12 +324,14 @@ requires-dist = [
     { name = "pyproj", specifier = ">=3.7.2" },
     { name = "pyreadstat", specifier = ">=1.3.3" },
     { name = "pytesseract", specifier = ">=0.3.13" },
+    { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "scipy", specifier = ">=1.17.1" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "shapely", specifier = ">=2.1.2" },
     { name = "statsmodels", specifier = ">=0.14.6" },
     { name = "tqdm", specifier = ">=4.67.3" },
+    { name = "uvicorn", specifier = ">=0.41.0" },
     { name = "xgboost", specifier = ">=3.2.0" },
 ]
 
@@ -324,6 +364,21 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/9d/ab66a06e416d71b7bdcb9904cdf8d4db3379ef632bb8e9495646702d9718/duckdb-1.4.4.tar.gz", hash = "sha256:8bba52fd2acb67668a4615ee17ee51814124223de836d9e2fdcbc4c9021b3d3c", size = 18419763, upload-time = "2026-01-26T11:50:37.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/a6/f19e2864e651b0bd8e4db2b0c455e7e0d71e0d4cd2cd9cc052f518e43eb3/duckdb-1.4.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:25874f8b1355e96178079e37312c3ba6d61a2354f51319dae860cf21335c3a20", size = 28909554, upload-time = "2026-01-26T11:50:00.107Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/93/8a24e932c67414fd2c45bed83218e62b73348996bf859eda020c224774b2/duckdb-1.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:452c5b5d6c349dc5d1154eb2062ee547296fcbd0c20e9df1ed00b5e1809089da", size = 15353804, upload-time = "2026-01-26T11:50:03.382Z" },
+    { url = "https://files.pythonhosted.org/packages/62/13/e5378ff5bb1d4397655d840b34b642b1b23cdd82ae19599e62dc4b9461c9/duckdb-1.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8e5c2d8a0452df55e092959c0bfc8ab8897ac3ea0f754cb3b0ab3e165cd79aff", size = 13676157, upload-time = "2026-01-26T11:50:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/94/24364da564b27aeebe44481f15bd0197a0b535ec93f188a6b1b98c22f082/duckdb-1.4.4-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1af6e76fe8bd24875dc56dd8e38300d64dc708cd2e772f67b9fbc635cc3066a3", size = 18426882, upload-time = "2026-01-26T11:50:08.97Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/6ae31b2914b4dc34243279b2301554bcbc5f1a09ccc82600486c49ab71d1/duckdb-1.4.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0440f59e0cd9936a9ebfcf7a13312eda480c79214ffed3878d75947fc3b7d6d", size = 20435641, upload-time = "2026-01-26T11:50:12.188Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b1/fd5c37c53d45efe979f67e9bd49aaceef640147bb18f0699a19edd1874d6/duckdb-1.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:59c8d76016dde854beab844935b1ec31de358d4053e792988108e995b18c08e7", size = 12762360, upload-time = "2026-01-26T11:50:14.76Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2d/13e6024e613679d8a489dd922f199ef4b1d08a456a58eadd96dc2f05171f/duckdb-1.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:53cd6423136ab44383ec9955aefe7599b3fb3dd1fe006161e6396d8167e0e0d4", size = 13458633, upload-time = "2026-01-26T11:50:17.657Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -339,6 +394,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
 ]
 
 [[package]]
@@ -390,6 +461,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8d/24/5eb5685d7bf89d64218919379f882d19a60f8219d66d833c83b1cf264c95/geopandas-1.1.2.tar.gz", hash = "sha256:33f7b33565c46a45b8459a2ab699ec943fdbb5716e58e251b3c413cf7783106c", size = 336037, upload-time = "2025-12-22T21:06:13.749Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/e4/fac19dc34cb686c96011388b813ff7b858a70681e5ce6ce7698e5021b0f4/geopandas-1.1.2-py3-none-any.whl", hash = "sha256:2bb0b1052cb47378addb4ba54c47f8d4642dcbda9b61375638274f49d9f0bb0d", size = 341734, upload-time = "2025-12-22T21:06:12.498Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -468,6 +557,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -585,6 +686,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/ae/07d4a5fcaa5509221287d289323d75ac8eda5a5a4ac9de2accf7bbcc2b88/markdown2-2.5.5.tar.gz", hash = "sha256:001547e68f6e7fcf0f1cb83f7e82f48aa7d48b2c6a321f0cd20a853a8a2d1664", size = 157249, upload-time = "2026-03-02T20:46:53.411Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/af/4b3891eb0a49d6cfd5cbf3e9bf514c943afc2b0f13e2c57cc57cd88ecc21/markdown2-2.5.5-py3-none-any.whl", hash = "sha256:be798587e09d1f52d2e4d96a649c4b82a778c75f9929aad52a2c95747fa26941", size = 56250, upload-time = "2026-03-02T20:46:52.032Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -991,6 +1122,60 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1147,6 +1332,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]
@@ -1377,6 +1571,18 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
 name = "statsmodels"
 version = "0.14.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1447,12 +1653,46 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- FastAPI app with DuckDB querying gzip CSVs directly — no separate database needed
- Four data sections: arrests, crime incidents, 311 service requests, police stops
- Geographic filtering by ward and district throughout
- Plotly JS charts (CDN) rendered client-side
- Jinja2 templates with shared base layout, nav, and CSS
- Ward values standardized as strings across ETL and query layer

## Structure

```
app/
├── main.py           # app entry point, router registration
├── data.py           # all DuckDB queries
├── routers/          # arrests, incidents, service_311, stops
├── templates/        # base.html + per-topic subdirectories
└── static/css/
```

## Test plan

- [ ] `uv run uvicorn app.main:app --reload --port 8000` starts without errors
- [ ] Arrests, incidents, 311, and stops pages load with data
- [ ] Ward/district filters work on each section
- [ ] No broken chart or template errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)